### PR TITLE
feat: PR for issue #19

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,16 @@ Configure webpack to load extensions `['.web.js', '.js']`:
 }
 ```
 
+### Consent banner/dialog language
+
+If you want to force the language of consent (for i18n):
+
+```js
+  <CookieBot domainGroupId={domainGroupId} language="ES" />
+```
+
+If consent with that language is no defined, the default language are loaded (or auto-detect).
+
 ## Contributing
 
 If you want to contribute to react-cookiebot please see our [contributing and community guidelines](https://github.com/yeutech-lab/react-cookiebot/blob/master/.github/CONTRIBUTING.md), they\'ll help you get set up locally and explain the whole process.

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A simple react cookie bot component that configure Cookiebot in your [`react`](h
   - [Documentation](#documentation)
   - [Create a cookie bot account](#create-a-cookie-bot-account)
   - [Configuration](#configuration)
+     - [Consent banner/dialog language](#consent-banner-dialog-language)
   - [Contributing](#contributing)
   - [License MIT](#license-mit)
 

--- a/src/CookieBot.js
+++ b/src/CookieBot.js
@@ -9,6 +9,7 @@ import PropTypes from 'prop-types';
  */
 function CookieBot({
   domainGroupId,
+  language,
 }) {
   if (!domainGroupId || !document) {
     return null;
@@ -22,6 +23,7 @@ function CookieBot({
   script.setAttribute('data-cbid', domainGroupId);
   script.setAttribute('data-blockingmode', 'auto');
   script.setAttribute('type', 'text/javascript');
+  if (language) script.setAttribute('data-culture', language);
   const head = document.querySelector('html > head');
   head.insertBefore(script, head.firstChild);
   return (
@@ -29,14 +31,21 @@ function CookieBot({
       id="CookieDeclaration"
       src={`https://consent.cookiebot.com/${domainGroupId}/cd.js`}
       type="text/javascript"
+      data-culture={language}
       async
     />
   );
 }
 
+CookieBot.defaultProps = {
+  language: null,
+};
+
 CookieBot.propTypes = {
   /** Cookie bot domain group id */
   domainGroupId: PropTypes.string.isRequired,
+  /** Cookie bot language */
+  language: PropTypes.string,
 };
 
 export default CookieBot;


### PR DESCRIPTION
# PR for issue #19

## Description

As Cookiebot [explain on their website](https://support.cookiebot.com/hc/en-us/articles/360003793394-How-do-I-set-the-language-of-the-consent-banner-dialog-), if you have a Domain group consent configurated with many languages, you can set witch language consent you want yo show or put on auto-detect. Most of the times auto-detect is enought, buy if you have a multi-language site would be interested to force to use the language that you are seeing the rest of the website.

# Versions

- react-cookiebot: 1.0.8